### PR TITLE
Update robo.py

### DIFF
--- a/automo/robo.py
+++ b/automo/robo.py
@@ -59,7 +59,7 @@ import unicodedata
 import ConfigParser
 from os.path import expanduser
 
-import automo.util as util
+import automo import util
 
 from distutils.dir_util import mkpath
 


### PR DESCRIPTION
@txmtwo apparently there is an underlying python3 core.
this relative import was wrong.
